### PR TITLE
Add validation for postcode and housenumber fields

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -1,6 +1,6 @@
 {
   "name": "trinos-nl/magento2-postcode-nl",
-  "version": "1.0.4",
+  "version": "1.0.5",
   "description": "Hyvä Checkout integration for Postcode.nl to validate Dutch addresses at Checkout",
   "type": "magento2-module",
   "require": {

--- a/src/Model/Form/EntityFormModifier/WithPostcodecheckModifier.php
+++ b/src/Model/Form/EntityFormModifier/WithPostcodecheckModifier.php
@@ -92,11 +92,19 @@ class WithPostcodecheckModifier implements EntityFormModifierInterface
         $housenumber = $street->getRelatives()[1] ?? null;
         $addition = $street->getRelatives()[2] ?? null;
 
+        if (!$postcode?->getValue() || !$housenumber?->getValue()) {
+            return null;
+        }
+
         $response = json_decode($this->postcodeManagement->getPostcodeInformation(
             $postcode->getValue() ?? '',
             $housenumber?->getValue() ?? '',
             $addition?->getValue() ?? '',
         ), true);
+
+        if (!$response) {
+            return null;
+        }
 
         if (isset($response['exception'])) {
             $manualMode->setAttribute('data-msg-magewire', $response['exception']);


### PR DESCRIPTION
Added checks to ensure postcode and housenumber values are present before requesting postcode information. Also added a check to return null if the response is empty, improving robustness against invalid input.