### PR TITLE
Add hyva CSP compatibility

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -1,11 +1,12 @@
 {
   "name": "trinos-nl/magento2-postcode-nl",
-  "version": "1.0.6",
+  "version": "1.1.0",
   "description": "Hyvä Checkout integration for Postcode.nl to validate Dutch addresses at Checkout",
   "type": "magento2-module",
   "require": {
     "magento/framework": "*",
-    "hyva-themes/magento2-hyva-checkout": ">=1.1"
+    "hyva-themes/magento2-hyva-checkout": ">=1.1",
+    "hyva-themes/magento2-theme-module": ">=1.3.11"
   },
   "authors": [
     {
@@ -13,7 +14,7 @@
       "email": "thijs@trinos.nl"
     }
   ],
- "license": [
+  "license": [
     "OSL-3.0"
   ],
   "autoload": {

--- a/src/view/frontend/templates/page/js/api/v1/validation/postcode-validation.phtml
+++ b/src/view/frontend/templates/page/js/api/v1/validation/postcode-validation.phtml
@@ -3,12 +3,15 @@
 declare(strict_types=1);
 
 use Hyva\Theme\Model\ViewModelRegistry;
+use Hyva\Theme\ViewModel\HyvaCsp;
 use Magento\Framework\Escaper;
 use Magento\Framework\View\Element\Template;
 
 /** @var Template $block */
 /** @var Escaper $escaper */
 /** @var ViewModelRegistry $viewModels */
+
+$hyvaCsp = $viewModels->require(HyvaCsp::class);
 ?>
 <script>
     'use strict';
@@ -27,3 +30,4 @@ use Magento\Framework\View\Element\Template;
         })
     })();
 </script>
+<?php $hyvaCsp->registerInlineScript(); ?>


### PR DESCRIPTION
This change adds compatibility with Hyva CSP. 

This introduces a new dependency on `"hyva-themes/magento2-theme-module": ">=1.3.11"`. Because of this we will release this as a new minor version

Resolves #27